### PR TITLE
Add passplum link and Google Analytics

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -27,9 +27,31 @@ import { navItems } from "../lib/nav";
                 ))
               }
             </div>
-            <p class="text-sm text-zinc-400 dark:text-zinc-500">
-              &copy; {new Date().getFullYear()} Max Beatty
-            </p>
+            <div class="flex items-center gap-4">
+              <a
+                href="/rss.xml"
+                class="text-zinc-400 transition hover:text-sky-500 dark:text-zinc-500 dark:hover:text-sky-400"
+                aria-label="RSS Feed"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke-width="1.5"
+                  stroke="currentColor"
+                  class="size-5"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M12.75 19.5v-.75a7.5 7.5 0 0 0-7.5-7.5H4.5m0-6.75h.75c7.87 0 14.25 6.38 14.25 14.25v.75M6 18.75a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z"
+                  ></path>
+                </svg>
+              </a>
+              <p class="text-sm text-zinc-400 dark:text-zinc-500">
+                &copy; {new Date().getFullYear()} Max Beatty
+              </p>
+            </div>
           </div>
         </Container>
       </div>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -63,6 +63,13 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site);
         />
       )
     }
+    <script is:inline async src="https://www.googletagmanager.com/gtag/js?id=G-R3BFQTWJX1"></script>
+    <script is:inline>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-R3BFQTWJX1');
+    </script>
     <script is:inline>
       try {
         var theme =

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -22,7 +22,7 @@ const projects = [
     name: "Pass Plum",
     description:
       "A password generator that creates memorable passphrases using common English words.",
-    href: "https://github.com/maxbeatty/passplum",
+    href: "https://passplum.maxbeatty.com/",
   },
   {
     name: "dotenv",


### PR DESCRIPTION
## Summary
- Link to running passplum instance
- Add Google Analytics (gtag.js) tracking with measurement ID G-R3BFQTWJX1

## Test plan
- [ ] Verify Google Analytics script loads on page
- [ ] Verify passplum link is present and correct
- [ ] Check no regressions on existing pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)