### PR TITLE
Pin lychee to 0.23.0

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,3 @@
 [tools]
 node = "lts"
-lychee = "latest"
+lychee = "0.23.0"


### PR DESCRIPTION
## Summary
- mise's lychee 0.24.1 install fails in CI with `lychee couldn't exec process: No such file or directory`, breaking the `linkcheck` step on every open PR (#103, #104, #105, #106) since the 0.24.1 release
- Pin to last-known-good 0.23.0 in `mise.toml` so CI stays green
- Once merged, rebasing the open dependabot PRs should clear them

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, rebase #103/#104/#105/#106 and confirm they go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)